### PR TITLE
fix panic on drop

### DIFF
--- a/src/ffi/linux.rs
+++ b/src/ffi/linux.rs
@@ -121,9 +121,11 @@ impl NativeManager {
 }
 impl Drop for NativeManager {
     fn drop(&mut self) {
-        while let Some(device) = self.devices.pop() {
-            self.disconnect(device.fd);
+        let fds: Vec<i32> = self.devices.iter().map(|dev| dev.fd).collect();
+        for fd in fds {
+            self.disconnect(fd);
         }
+        self.devices.clear();
         unsafe {
             close(self.fd);
         }


### PR DESCRIPTION
drop() must not pop() device from self.devices before calling
self.disconnect(fd), because disconnect expects to find the device in
self.devices, or it will panic:

thread 'main' panicked at 'There was no fd of 6', ~/.cargo/registry/src/github.com-1ecc6299db9ec823/stick-0.7.1/src/ffi/linux.rs:119:9

**NOTE:** PR is relative to 0.7.1, not to master, because master doesn't compile for me. (Path to smelling-salts doesn't resolve.)