### PR TITLE
[WIP] TOML device descriptor definition & Thrustmaster Warthog throttle definition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,8 @@ default-target = "x86_64-unknown-linux-gnu"
 default = []
 std = []
 docs-rs = []
+
+[dependencies]
+toml = "0.5.6"
+serde = "1.0.110"
+serde_derive = "1.0.110"

--- a/src/controllers/warthog_throttle.toml
+++ b/src/controllers/warthog_throttle.toml
@@ -1,4 +1,4 @@
-name = 'ThrustmasterWarthogThrottle'
+name = 'Thrustmaster Warthog Throttle'
 id = '44F0404'
 
 [[axes]]
@@ -25,8 +25,6 @@ name = 'ThrottleL'
 [axes.action]
 code = 6
 name = 'Slew'
-
-[triggers]
 
 [[buttons]]
 code = 713
@@ -156,3 +154,9 @@ name = 'ChForward'
 code = 299
 name = 'ChBackward'
 
+[[hats]]
+name = "Hat"
+north = 544
+south = 545
+west = 546
+east = 547

--- a/src/controllers/warthog_throttle.toml
+++ b/src/controllers/warthog_throttle.toml
@@ -1,0 +1,158 @@
+name = 'ThrustmasterWarthogThrottle'
+id = '44F0404'
+
+[[axes]]
+[axes.action]
+code = 0
+name = 'ScXAction'
+
+[[axes]]
+[axes.action]
+code = 1
+name = 'ScYAction'
+
+[[axes]]
+[axes.action]
+code = 2
+name = 'ThrottleR'
+
+[[axes]]
+[axes.action]
+code = 5
+name = 'ThrottleL'
+
+[[axes]]
+[axes.action]
+code = 6
+name = 'Slew'
+
+[triggers]
+
+[[buttons]]
+code = 713
+pressed_name = 'AutopilotTogglePressed'
+released_name = 'AutopilotToggleReleased'
+
+[[buttons]]
+code = 708
+pressed_name = 'LandingGearSilencePressed'
+released_name = 'LandingGearSilenceReleased'
+
+[[buttons]]
+code = 302
+pressed_name = 'LtbPressed'
+released_name = 'LtbReleased'
+
+[[two_way]]
+code = 711
+high = 'EacArm'
+neutral = 'EacOff'
+
+[[two_way]]
+code = 712
+high = 'RadarAltimeterNormal'
+neutral = 'RadarAltimeterDisarm'
+
+[[two_way]]
+code = 707
+high = 'ApuStart'
+neutral = 'ApuOff'
+
+[[two_way]]
+code = 303
+high = 'EngineLeftNormal'
+neutral = 'EngineLeftOverride'
+
+[[two_way]]
+code = 704
+high = 'EngineRightNormal'
+neutral = 'EngineRightOverride'
+
+[[three_way]]
+neutral = 'AltitudeHeading'
+
+[three_way.high]
+code = 714
+name = 'Path'
+
+[three_way.low]
+code = 715
+name = 'Alt'
+
+[[three_way]]
+neutral = 'Maneuver'
+
+[three_way.high]
+code = 709
+name = 'Up'
+
+[three_way.low]
+code = 710
+name = 'Down'
+
+[[three_way]]
+neutral = 'LeftNormal'
+
+[three_way.high]
+code = 718
+name = 'LeftIgnition'
+
+[three_way.low]
+code = 705
+name = 'LeftMotor'
+
+[[three_way]]
+neutral = 'RightNormal'
+
+[three_way.high]
+code = 719
+name = 'RightIgnition'
+
+[three_way.low]
+code = 706
+name = 'RightMotor'
+
+[[three_way]]
+neutral = 'PsNeutral'
+
+[three_way.high]
+code = 300
+name = 'PsForward'
+
+[three_way.low]
+code = 301
+name = 'PsBackward'
+
+[[three_way]]
+neutral = 'SpdNeutral'
+
+[three_way.high]
+code = 294
+name = 'SpdForward'
+
+[three_way.low]
+code = 295
+name = 'SpdBackward'
+
+[[three_way]]
+neutral = 'BsNeutral'
+
+[three_way.high]
+code = 296
+name = 'BsForward'
+
+[three_way.low]
+code = 297
+name = 'BsBackward'
+
+[[three_way]]
+neutral = 'ChNeutral'
+
+[three_way.high]
+code = 298
+name = 'ChForward'
+
+[three_way.low]
+code = 299
+name = 'ChBackward'
+

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -1,0 +1,87 @@
+/// Describes some gamepad
+use std::fs::OpenOptions;
+use std::io::{Read};
+use std::path::PathBuf;
+
+use serde_derive::{Deserialize, Serialize};
+use toml::value::{ Table};
+
+#[derive(Deserialize, Debug, Serialize)]
+/// Describes some hardware joystick mapping
+pub(crate) struct DeviceDescriptor {
+    /// Name of device.
+    pub(crate) name: String,
+    /// Hardware ID of device.
+    pub(crate) id: String,
+    /// Collection of axes belonging to this device.
+    pub(crate) axes: Vec<AxisEvent>,
+    /// Collection of triggers belonging to this device.
+    pub(crate) triggers: Table,
+    /// Collection of buttons belonging to this device.
+    pub(crate) buttons: Vec<ButtonEvent>,
+    /// Collection of two-way switches belonging to this device.
+    pub(crate) two_way: Vec<TwoWaySwitchEvent>,
+    /// Collection of three-way switches belonging to this device.
+    pub(crate) three_way: Vec<ThreeWaySwitchEvent>,
+}
+
+impl DeviceDescriptor {
+    #[allow(dead_code)]
+    /// Reads a device description file into a struct.
+    pub(crate) fn from_toml(input: PathBuf) -> Self {
+        let mut contents = String::new();
+        let mut file = OpenOptions::new().read(true).open(input).unwrap();
+        file.read_to_string(&mut contents).unwrap();
+        let data: DeviceDescriptor = toml::from_str(&contents).unwrap();
+        data
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+/// Represents some named two-state event.
+pub(crate) struct Event {
+    /// Event ID.
+    pub(crate) code: u32,
+    /// Emitted event name.
+    pub(crate) name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+/// Represents an Axis.
+pub(crate) struct AxisEvent {
+    /// Name of event emitted when this axis changes.
+    pub(crate) action: Event
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+/// Represents a button.
+pub(crate) struct ButtonEvent {
+    /// Event ID for this button
+    pub(crate) code: u32,
+    /// Name of event emitted when button is pressed.
+    pub(crate) pressed_name: String,
+    /// Name of event emitted when button is released.
+    pub(crate) released_name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+/// Represents a two-way switch.
+pub(crate) struct TwoWaySwitchEvent {
+    // Event ID for this switch
+    pub(crate) code: u32,
+    // Name of event emitted when the switch is in its high "on" state.
+    pub(crate) high: String,
+    // Name of event emitted when the switch is in its neutral "off" state
+    pub(crate) neutral: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+/// Three-way switch event
+pub(crate) struct ThreeWaySwitchEvent {
+    // Name of event emitted when the switch is in its neutral "middle" state
+    pub(crate) neutral: String,
+    // Name of event emitted when the switch is in its High "up" state
+    pub(crate) high: Event,
+    // Name of event emitted when the switch is in its Low "down" state
+    pub(crate) low: Event,
+}

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -9,20 +9,14 @@ use toml::value::{ Table};
 #[derive(Deserialize, Debug, Serialize)]
 /// Describes some hardware joystick mapping
 pub(crate) struct DeviceDescriptor {
-    /// Name of device.
     pub(crate) name: String,
-    /// Hardware ID of device.
     pub(crate) id: String,
-    /// Collection of axes belonging to this device.
     pub(crate) axes: Vec<AxisEvent>,
-    /// Collection of triggers belonging to this device.
-    pub(crate) triggers: Table,
-    /// Collection of buttons belonging to this device.
     pub(crate) buttons: Vec<ButtonEvent>,
-    /// Collection of two-way switches belonging to this device.
     pub(crate) two_way: Vec<TwoWaySwitchEvent>,
-    /// Collection of three-way switches belonging to this device.
     pub(crate) three_way: Vec<ThreeWaySwitchEvent>,
+    pub(crate) triggers: Option<Vec<AxisEvent>>,
+    pub(crate) hats: Option<Vec<HatEvent>>,
 }
 
 impl DeviceDescriptor {
@@ -84,4 +78,20 @@ pub(crate) struct ThreeWaySwitchEvent {
     pub(crate) high: Event,
     // Name of event emitted when the switch is in its Low "down" state
     pub(crate) low: Event,
+}
+
+
+#[derive(Serialize, Deserialize, Debug)]
+/// Hat.
+pub(crate) struct HatEvent {
+    /// Hat's name
+    pub(crate) name: String,
+    /// ID of north event.
+    pub(crate) north: u32,
+    /// ID of south event.
+    pub(crate) south: u32,
+    /// ID of west event.
+    pub(crate) west: u32,
+    // ID of east event.
+    pub(crate) east: u32,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 mod event;
 mod gamepad;
 mod port;
+mod descriptor;
 
 #[cfg_attr(target_arch = "wasm32", path = "ffi/wasm32.rs")]
 #[cfg_attr(


### PR DESCRIPTION
Relates to #8 

~~## Necessary core adjustments:~~
~~1. enum `crate::event::GenericEvent` added.~~
~~- Services as a platform-neutral representation of an event, with a platform-specific constructor for linux.~~
~~- Specific device drivers (Warthog Throttle in this PR) accept a `GenericEvent` and return a device-specific enum~~

~~2. `crate::Gamepad::poll` adjusted to insert hook to device-specific event decoders, which exist in a separate module.~~

~~3. create `mod.rs` in `src/controllers` to serve as a output directory for generated device drivers~~

## New features:
~~- created code generator from TOML templates using `askama` crate (similar to python's `jinja2` module)~~
  ~~- generator can be re-used, potentially, for other input types.~~
- added `DeviceDescriptor` utilizing the `toml` and, by extention `serde` crates for describing an arbitrary gamepad. Could be adapted for codegen features.
~~- create device driver for the Thrustmaster Warthog Throttle (#8) (generated)~~

## Examples:
~~- added README example to the `/examples` directory for ease of use. ~~


## TODO
- [X] create device descriptor file schema
- [X] Buttons
- [X] Axies
- [x] Triggers (Axies)
- [x] Hats
- [X] two-way switches
- [X] three-way switches

------------------

Things i think still need to be done:
Currently hardware detection is baked into the `src/ffi/linux.rs` through this private struct `HardwareId`, this isn't easily extendable in its current location which means new controllers would still need manual work to tie in. What im thinking is to expose a method in the `crate::controllers` module, that accepts a hardware ID and a `crate::event::GenericEvent` and returns an optional `crates::event::Event` object if the event is successfully handled. (optional to allow fallback behavior)

```rs
use crate::event::{Event, GenericEvent};

pub fn handle_event(event: GenericEvent) -> Option<Event>{
// ...
}
```

the contents of this function would be filled in by codegen.
A function such as this would minimize the changes that need to be made to the existing `stick::Gamepad::poll` method, basically adjusting my existing changes to this method.
