### PR TITLE
Add a missing input for the Warthog Throttle

### DIFF
--- a/pad_db/pad/mapping/03004F0404041101.toml
+++ b/pad_db/pad/mapping/03004F0404041101.toml
@@ -117,6 +117,10 @@ event = "EngineLIgnition"
 code = 431
 event = "EngineRIgnition"
 
+[[button]]
+code = 0
+event = "MousePush"
+
 # [[button]]
 # code = 256
 # event = "MicUp"


### PR DESCRIPTION
During my initial testing, i didn't notice that the "mouse" hat could be pressed in to trigger a button.
This PR adds this input, binding to the most consistent analog in the `Event` enum.

relates to #8 