### PR TITLE
Sometimes ioctal 0x_8018_4540 returns -1

### DIFF
--- a/stick/src/raw/linux.rs
+++ b/stick/src/raw/linux.rs
@@ -564,11 +564,20 @@ impl Controller {
 
         // Get the min and max absolute values for axis.
         let mut a = MaybeUninit::<AbsInfo>::uninit();
-        assert_ne!(
-            unsafe { ioctl(fd, 0x_8018_4540, a.as_mut_ptr().cast()) },
-            -1
-        );
-        let a = unsafe { a.assume_init() };
+        let a = if unsafe { ioctl(fd, 0x_8018_4540, a.as_mut_ptr().cast()) }
+            != -1
+        {
+            unsafe { a.assume_init() }
+        } else {
+            AbsInfo {
+                value: 0,
+                minimum: i16::MIN as i32,
+                maximum: i16::MAX as i32,
+                fuzz: 0,
+                flat: 0,
+                resolution: 0,
+            }
+        };
         let norm = (a.maximum as f64 - a.minimum as f64) * 0.5;
         let zero = a.minimum as f64 + norm;
         // Invert so multiplication can be used instead of division


### PR DESCRIPTION
Hi!

I have an embedded linux system that I'm trying to get some joysticks and steering wheels to work on. For some reason the ioctal EVIOCGABS(0x_8018_4540) returns -1. Maybe there is some kernal module or settings that i'm missing for this ioctal to work.

I could get values from the device with jstest and with this change it works with stick!

I don't know if  i16::MIN to i16::MAX is a sane default range but for two thrustmaster devices it seems to be correct.

Cheers!

Jonathan

