### PR TITLE
Add MSC timestamp event

### DIFF
--- a/stick/src/ctlr.rs
+++ b/stick/src/ctlr.rs
@@ -555,6 +555,7 @@ impl Controller {
             TrimDown(p) => self.button(Btn::TrimDown, TrimDown, p),
             TrimLeft(p) => self.button(Btn::TrimLeft, TrimLeft, p),
             TrimRight(p) => self.button(Btn::TrimRight, TrimRight, p),
+            Timestamp(p) => Poll::Ready(Timestamp(p)),
         }
     }
 }

--- a/stick/src/event.rs
+++ b/stick/src/event.rs
@@ -230,6 +230,8 @@ pub enum Event {
     ScrollY(f64),
     /// Scroll Button on a mouse
     Scroll(bool),
+    /// Timestamp event for the number of microseconds since last reset
+    Timestamp(u32),
 }
 
 impl Event {
@@ -335,6 +337,7 @@ impl Event {
             0x5B => Event::TrimDown(value != 0.0),
             0x5C => Event::TrimLeft(value != 0.0),
             0x5D => Event::TrimRight(value != 0.0),
+            0x5E => Event::Timestamp(value as u32),
             n => Event::Number((n & !0x80) as i8, value != 0.0),
         }
     }
@@ -438,6 +441,7 @@ impl Event {
             TrimDown(p) => (0x5B, f64::from(u8::from(p))),
             TrimLeft(p) => (0x5C, f64::from(u8::from(p))),
             TrimRight(p) => (0x5D, f64::from(u8::from(p))),
+            Timestamp(p) => (0x5E, p as f64),
         }
     }
 }
@@ -554,6 +558,7 @@ impl std::fmt::Display for Event {
             ActionL(p) => write!(f, "ActionL {}", pushed(p)),
             ActionR(p) => write!(f, "ActionR {}", pushed(p)),
             Pinky(p) => write!(f, "Pinky {}", pushed(p)),
+            Timestamp(p) => write!(f, "Timestamp {}μs", p),
         }
     }
 }

--- a/stick/src/raw/linux.rs
+++ b/stick/src/raw/linux.rs
@@ -291,19 +291,56 @@ fn linux_abs_to_stick_event(
     }
 }
 
+// Convert Linux ABS axis to stick Event.
+fn linux_msc_to_stick_event(
+    pending: &mut Vec<Event>,
+    msc_event: c_ushort,
+    msc_value: c_int,
+) {
+    match msc_event {
+        0x00 /* MSC_SERIAL */ => {
+            eprintln!("Unknown Event: MSC_SERIAL");
+            eprintln!("Report at https://github.com/libcala/stick/issues");
+        }
+        0x01 /* MSC_PULSELED */ => {
+            eprintln!("Unknown Event: MSC_PULSELED");
+            eprintln!("Report at https://github.com/libcala/stick/issues");
+        }
+        0x02 /* MSC_GESTURE */ => {
+            eprintln!("Unknown Event: MSC_GESTURE");
+            eprintln!("Report at https://github.com/libcala/stick/issues");
+        }
+        0x03 /* MSC_RAW */ => {
+            eprintln!("Unknown Event: MSC_RAW");
+            eprintln!("Report at https://github.com/libcala/stick/issues");
+        }
+        0x04 /* MSC_SCAN */ => {
+            eprintln!("Unknown Event: MSC_SCAN");
+            eprintln!("Report at https://github.com/libcala/stick/issues");
+        }
+        0x05 /* MSC_TIMESTAMP */ => pending.push(Event::Timestamp(msc_value as u32)),
+
+        // there is no 0x06 defined
+
+        0x06 /* MSC_MAX */ => {
+            eprintln!("Unknown Event: MSC_MAX");
+            eprintln!("Report at https://github.com/libcala/stick/issues");
+        }
+
+        _unknown => {
+            eprintln!("Unknown Linux MSC {}", _unknown);
+            eprintln!("Report at https://github.com/libcala/stick/issues");
+        }
+    }
+}
+
 fn linux_evdev_to_stick_event(pending: &mut Vec<Event>, e: EvdevEv) {
     match e.ev_type {
         0x00 /* SYN */ => {}, // Ignore Syn Input Events
         0x01 /* BTN */ => linux_btn_to_stick_event(pending, e.ev_code, e.ev_value != 0),
         0x02 /* REL */ => linux_rel_to_stick_event(pending, e.ev_code, e.ev_value),
         0x03 /* ABS */ => linux_abs_to_stick_event(pending, e.ev_code, e.ev_value),
-        0x04 /* MSC */ => {
-            if e.ev_code != 4 { // Ignore Misc./Scan Events
-                let (code, val) = (e.ev_code, e.ev_value);
-                eprintln!("Unknown Linux Misc Code: {}, Value: {}", code, val);
-                eprintln!("Report at https://github.com/libcala/stick/issues");
-            }
-        }
+        0x04 /* MSC */ => linux_msc_to_stick_event(pending, e.ev_code, e.ev_value),
         0x15 /* FF */ => {}, // Ignore Force Feedback Input Events
         _unknown => {
             eprintln!("Unknown Linux Event Type: {}", _unknown);

--- a/stick/src/raw/linux.rs
+++ b/stick/src/raw/linux.rs
@@ -322,7 +322,7 @@ fn linux_msc_to_stick_event(
 
         // there is no 0x06 defined
 
-        0x06 /* MSC_MAX */ => {
+        0x07 /* MSC_MAX */ => {
             eprintln!("Unknown Event: MSC_MAX");
             eprintln!("Report at https://github.com/libcala/stick/issues");
         }

--- a/stick/src/raw/linux.rs
+++ b/stick/src/raw/linux.rs
@@ -291,7 +291,7 @@ fn linux_abs_to_stick_event(
     }
 }
 
-// Convert Linux ABS axis to stick Event.
+// Convert Linux MSC event to stick Event.
 fn linux_msc_to_stick_event(
     pending: &mut Vec<Event>,
     msc_event: c_ushort,


### PR DESCRIPTION
Adds handling for timestamp events on linux. These events are sent by Nintendo joycons(I'm not aware of any other controller that sends this information) As I understand this can be used to correlate timing with gyro/accelerometer readings sent. (See [here](https://github.com/nicman23/dkms-hid-nintendo/blob/master/src/hid-nintendo.c#L1036-L1082) )

Here's the relevant part of the [event code documentation](https://www.kernel.org/doc/Documentation/input/event-codes.txt)

```
EV_MSC:
----------
EV_MSC events are used for input and output events that do not fall under other
categories.

A few EV_MSC codes have special meaning:

* MSC_TIMESTAMP:
  - Used to report the number of microseconds since the last reset. This event
    should be coded as an uint32 value, which is allowed to wrap around with
    no special consequence. It is assumed that the time difference between two
    consecutive events is reliable on a reasonable time scale (hours).
    A reset to zero can happen, in which case the time since the last event is
    unknown.  If the device does not provide this information, the driver must
    not provide it to user space.
```


Also: I'm not sure whats the from_id and to_id stuff and just added the next number in the series. 