### PR TITLE
add pinky button candidates

### DIFF
--- a/stick/src/raw/linux.rs
+++ b/stick/src/raw/linux.rs
@@ -66,6 +66,8 @@ fn linux_btn_to_stick_event(
         0x13C /* BTN_MODE */ => Event::Exit(pushed),
         0x13D /* BTN_THUMBL */ => Event::Joy(pushed),
         0x13E /* BTN_THUMBR */ => Event::Cam(pushed),
+        0x13F /* BTN_PINKYR */ => Event::PinkyRight(pushed),
+        0x140 /* BTN_PINKYL */ => Event::PinkyLeft(pushed),
 
         0x220 /* BTN_DPAD_UP */ => Event::Up(pushed),
 		0x221 /* BTN_DPAD_DOWN */ => Event::Down(pushed),


### PR DESCRIPTION
Due to my controller having a button `0x13F` and this library not recognizing it, I'm taking a blind shot in the dark as to which enum it should represent.

Paddles were taken, and PinkyL/R weren't, so given the buttons are close enough to my pinkies I figure that might be it. The order could easily go either way, but in my instance the 13F happens to be on my right side.
