### PR TITLE
Impl futures::stream::Stream for Controller/Listener

### DIFF
--- a/stick/Cargo.toml
+++ b/stick/Cargo.toml
@@ -36,3 +36,8 @@ default = ["sdb"]
 gcdb = []
 # Include the stick controller database (button/axis remappings).
 sdb = []
+# Include futures::stream::Stream impl.
+stream = ["dep:futures"]
+
+[dependencies]
+futures = { version = "0.3.30", optional = true }

--- a/stick/src/ctlr.rs
+++ b/stick/src/ctlr.rs
@@ -580,6 +580,23 @@ impl Future for Controller {
     }
 }
 
+#[cfg(feature = "stream")]
+impl futures::stream::Stream for Controller {
+    type Item = Event;
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Event>> {
+        match self.poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(e) => match e {
+                Event::Disconnect => Poll::Ready(None),
+                e => Poll::Ready(Some(e)),
+            },
+        }
+    }
+}
+
 pub trait Rumble {
     fn left(&self) -> f32;
     fn right(&self) -> f32;

--- a/stick/src/listener.rs
+++ b/stick/src/listener.rs
@@ -36,3 +36,16 @@ impl Future for Listener {
         Pin::new(&mut self.get_mut().0).poll(cx)
     }
 }
+#[cfg(feature = "stream")]
+impl futures::stream::Stream for Listener {
+    type Item = crate::Controller;
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        match self.poll(cx) {
+            Poll::Ready(c) => Poll::Ready(Some(c)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}


### PR DESCRIPTION
In the example tokio usage in https://github.com/ardaku/stick/issues/45 it spawns an async task for each controller,
I thought it would be nice to be able to treat each controller as a stream and poll all controllers from a `StreamMap`, I implemented stream for `Listener` too, but didn't actually end up using it.

This allows something to the effect of the following to work, with the `Controller` automatically removed from the stream map on `Event::Disconnect`.

```
let mut stream_map = StreamMap::new();
loop {
    tokio::select! {
        c = &mut listener => {
            stdout.write_all(format!("Listener: {:?}\n", c).as_bytes()).await?;
            stream_map.insert(c.id(), c);     
        }
        Some(e) = stream_map.next() => stdout.write_all(format!("Event: {:?}", e).as_bytes()).await?,
    }
}
```

The main reason I added it in it's own feature is because it adds a new dependency on the `futures` crate.
Given that I wasn't sure if you would not want it to be in by default.